### PR TITLE
TSS-309/use-the-public-ecr-repo-intead-of-docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:stable
+FROM public.ecr.aws/docker/library/docker:stable
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This [GitHub Action](https://github.com/features/actions) sets up Bitnami Kafka instance
 
-This project started as a a fork of https://github.com/bbcCorp/kafka-actions, and got adjusted to work with Kafka 3.2.0 and Zookeeper 2.8.1
+This project started as a a fork of <https://github.com/bbcCorp/kafka-actions>, and got adjusted to work with Kafka 3.2.0 and Zookeeper 2.8.1
 
 ---
 


### PR DESCRIPTION
# [TSS-309]

This PR switches the container image to be pulled from AWS public ecr repo as opposed to dockerhub.
This will help with dockerhub throttling.


[TSS-309]: https://candis.atlassian.net/browse/TSS-309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ