### PR TITLE
TSS-395/use-ecr-pull-through-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ This project started as a a fork of <https://github.com/bbcCorp/kafka-actions>, 
 
 ---
 
+## Publishing a new version
+
+After merging your changes create and push a versioned release. Example with version 1.1.0.
+
+```sh
+gh release create v1.1.0 --notes "this releases fixes many bugs"
+```
+
 ## Usage
 
 See [action.yml](action.yml)

--- a/action.yml
+++ b/action.yml
@@ -1,27 +1,32 @@
-name: 'Setup Bitnami Kafka'
-description: 'Setup Bitnami Kafka'
-author: 'candis'
+name: "Setup Bitnami Kafka"
+description: "Setup Bitnami Kafka"
+author: "candis"
 inputs:
   kafka version:
-    description: 'Version of Bitnami Kafka to use'
+    description: "Version of Bitnami Kafka to use"
     required: false
-    default: 'latest'
+    default: "latest"
   zookeeper version:
-    description: 'Version of Bitnami Zookeeper to use'
+    description: "Version of Bitnami Zookeeper to use"
     required: false
-    default: 'latest'    
+    default: "latest"
   kafka port:
-    description: 'The port of Kafka host'
+    description: "The port of Kafka host"
     required: false
     default: 9092
   kafka client port:
-    description: 'The port for Kafka client connection'
+    description: "The port for Kafka client connection"
     required: false
     default: 29092
   zookeeper port:
-    description: 'The port of Zookeeper host'
+    description: "the port of zookeeper host"
     required: false
-    default: 2181    
+    default: 2181
+  container_cache_url:
+    description: "The URL of the container cache, if ommited images will be pulled from Docker Hub"
+    required: false
+    default: ""
+
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ KAFKA_NETWORK="gh-kafka-network"
 docker network create $KAFKA_NETWORK --driver bridge
 
 echo "Running Zookeeper container"
-docker run -d --name zookeeper --network $KAFKA_NETWORK -p $INPUT_ZOOKEEPER_PORT:2181 -e ALLOW_ANONYMOUS_LOGIN=yes "${INPUT_CACHE_URL}bitnami/zookeeper:${INPUT_ZOOKEEPER_VERSION}"
+docker run -d --name zookeeper --network $KAFKA_NETWORK -p $INPUT_ZOOKEEPER_PORT:2181 -e ALLOW_ANONYMOUS_LOGIN=yes "${INPUT_CONTAINER_CACHE_URL}bitnami/zookeeper:${INPUT_ZOOKEEPER_VERSION}"
 
 echo "Running Kafka container"
 docker run -d --name kafka --network $KAFKA_NETWORK -p $INPUT_KAFKA_PORT:9092 \
@@ -15,4 +15,4 @@ docker run -d --name kafka --network $KAFKA_NETWORK -p $INPUT_KAFKA_PORT:9092 \
   -e KAFKA_CFG_INTER_BROKER_LISTENER_NAME=CLIENT \
   -e KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true \
   -e KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
-  -e ALLOW_PLAINTEXT_LISTENER=yes "${INPUT_CACHE_URL}bitnami/kafka:${INPUT_KAFKA_VERSION}"
+  -e ALLOW_PLAINTEXT_LISTENER=yes "${INPUT_CONTAINER_CACHE_URL}bitnami/kafka:${INPUT_KAFKA_VERSION}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ KAFKA_NETWORK="gh-kafka-network"
 docker network create $KAFKA_NETWORK --driver bridge
 
 echo "Running Zookeeper container"
-docker run -d --name zookeeper --network $KAFKA_NETWORK -p $INPUT_ZOOKEEPER_PORT:2181 -e ALLOW_ANONYMOUS_LOGIN=yes bitnami/zookeeper:$INPUT_ZOOKEEPER_VERSION
+docker run -d --name zookeeper --network $KAFKA_NETWORK -p $INPUT_ZOOKEEPER_PORT:2181 -e ALLOW_ANONYMOUS_LOGIN=yes "${INPUT_CACHE_URL}bitnami/zookeeper:${INPUT_ZOOKEEPER_VERSION}"
 
 echo "Running Kafka container"
 docker run -d --name kafka --network $KAFKA_NETWORK -p $INPUT_KAFKA_PORT:9092 \
@@ -15,4 +15,4 @@ docker run -d --name kafka --network $KAFKA_NETWORK -p $INPUT_KAFKA_PORT:9092 \
   -e KAFKA_CFG_INTER_BROKER_LISTENER_NAME=CLIENT \
   -e KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true \
   -e KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
-  -e ALLOW_PLAINTEXT_LISTENER=yes bitnami/kafka:$INPUT_KAFKA_VERSION
+  -e ALLOW_PLAINTEXT_LISTENER=yes "${INPUT_CACHE_URL}bitnami/kafka:${INPUT_KAFKA_VERSION}"


### PR DESCRIPTION
# [TSS-395]

This PR switches the kafka custom action to use our ecr pull through cache, both images arou around 300mb, so on each PR we are pulling at least 600mb from the internet.


[TSS-395]: https://candis.atlassian.net/browse/TSS-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ