### PR TITLE
chore(): use bitnamilegacy images

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This [GitHub Action](https://github.com/features/actions) sets up Bitnami Kafka instance
 
-This project started as a a fork of <https://github.com/bbcCorp/kafka-actions>, and got adjusted to work with Kafka 3.2.0 and Zookeeper 2.8.1
+This project started as a a fork of <https://github.com/bbcCorp/kafka-actions>, and got adjusted to work with Kafka 3.7.1 and Zookeeper 2.8.1
 
 ---
 
@@ -17,7 +17,7 @@ Basic:
   uses: candis/kafka-actions@v0.0.2
   # Optionally input values can be provided as follows:
   with: 
-    kafka version: 3.2.0
+    kafka version: 3.7.1
     zookeeper version: 3.7.1
 
 ```
@@ -41,7 +41,7 @@ export INPUT_ZOOKEEPER_PORT=2181
 export INPUT_ZOOKEEPER_VERSION=3.7.1
 export INPUT_KAFKA_PORT=9092
 export INPUT_KAFKA_CLIENT_PORT=29092
-export INPUT_KAFKA_VERSION=3.2.0
+export INPUT_KAFKA_VERSION=3.7.1
 ```
 
 ---

--- a/action.yml
+++ b/action.yml
@@ -5,11 +5,11 @@ inputs:
   container image kafka:
     description: "The container image to be used without the version, can be provided with the container repo or without it (assumes dockerhub by default). "
     required: false
-    default: "public.ecr.aws/bitnami/kafka"
+    default: "public.ecr.aws/bitnamilegacy/kafka"
   container image zookeeper:
     description: "The container image to be used without the version, can be provided with the container repo or without it (assumes dockerhub by default). "
     required: false
-    default: "public.ecr.aws/bitnami/zookeeper"
+    default: "public.ecr.aws/bitnamilegacy/zookeeper"
   kafka version:
     description: "Version of Bitnami Kafka to use"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -5,11 +5,11 @@ inputs:
   container image kafka:
     description: "The container image to be used without the version, can be provided with the container repo or without it (assumes dockerhub by default). "
     required: false
-    default: "public.ecr.aws/bitnamilegacy/kafka"
+    default: "bitnamilegacy/kafka"
   container image zookeeper:
     description: "The container image to be used without the version, can be provided with the container repo or without it (assumes dockerhub by default). "
     required: false
-    default: "public.ecr.aws/bitnamilegacy/zookeeper"
+    default: "bitnamilegacy/zookeeper"
   kafka version:
     description: "Version of Bitnami Kafka to use"
     required: false


### PR DESCRIPTION
⚠️ Important Notice: Upcoming changes to the Bitnami Catalog
This image is part of the brownout announced at [https://github.com/bitnami/containers/issues/83267⁠](https://github.com/bitnami/containers/issues/83267)

Beginning August 28th, 2025, Bitnami will evolve its public catalog to offer a curated set of hardened, security-focused images under the new [Bitnami Secure Images initiative⁠](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications). As part of this transition:

Bitnami will begin deprecating support for non-hardened, Debian-based software images in its free tier and will gradually remove tags from the public catalog. As a result, community users will have access to a reduced number of hardened images. These images are published only under the “latest” tag and are intended for development purposes
All existing container images have been migrated from the public catalog (docker.io/bitnami) to the “Bitnami Legacy” repository (docker.io/bitnamilegacy), where they will no longer receive updates.
For production workloads and long-term support, users are encouraged to adopt Bitnami Secure Images, which include hardened containers, smaller attack surfaces, CVE transparency (via VEX/KEV), SBOMs, and enterprise support.
These changes aim to improve the security posture of all Bitnami users by promoting best practices for software supply chain integrity and up-to-date deployments. For more details, visit the [Bitnami Secure Images announcement⁠](https://github.com/bitnami/containers/issues/83267).