### PR TITLE
TSS-1461/update-the-failing-actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/docker:stable
+FROM public.ecr.aws/docker/library/docker:29.0.2
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
#TSS-1461

Bump the image version for the docker image, the `stable` tag is 4 years old at this point, and some of our builds are failing.




[TSS-1461]: https://candis.atlassian.net/browse/TSS-1461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ